### PR TITLE
feat(ngx-structure-viewer): add filtering structure by chain

### DIFF
--- a/projects/demo-showcase/src/app/page-structure-viewer/sections/section-sources.component.ts
+++ b/projects/demo-showcase/src/app/page-structure-viewer/sections/section-sources.component.ts
@@ -5,11 +5,11 @@ import { Locus, Settings, Source } from '@ngx-structure-viewer';
 import { HttpClient } from '@angular/common/http';
 
 @Component({
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    templateUrl: './section-sources.component.html',
-    styleUrl: './section-sources.component.scss',
-    selector: 'app-section-sources',
-    standalone: false
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './section-sources.component.html',
+  styleUrl: './section-sources.component.scss',
+  selector: 'app-section-sources',
+  standalone: false
 })
 export class SectionSourcesComponent {
 
@@ -22,6 +22,7 @@ export class SectionSourcesComponent {
       format: 'mmcif',
       label: '8VAP',
       binary: false,
+      chain: "A",
     },
     {
       type: 'remote',
@@ -70,16 +71,16 @@ export class SectionSourcesComponent {
 
   // Define initial loci list
   readonly LOCI: Locus[] = [
-    { start: '1',   end: '10',  chain: 'A',   color: '#599a97' },
-    { start: '11',  end: '20',  chain: 'A',   color: '#28b525' },
-    { start: '21',  end: '30',  chain: 'A',   color: '#008a7c' },
-    { start: '31',  end: '40',  chain: 'A',   color: '#0faa05' },
-    { start: '41',  end: '50',  chain: 'A',   color: '#f8cb31' },
-    { start: '51',  end: '60',  chain: 'A',   color: '#77cb1c' },
-    { start: '61',  end: '70',  chain: 'A',   color: '#36ec09' },
-    { start: '71',  end: '80',  chain: 'A',   color: '#cbf17b' },
-    { start: '81',  end: '90',  chain: 'A',   color: '#5cb185' },
-    { start: '91',  end: '100', chain: 'A',   color: '#fee954' },
+    { start: '1', end: '10', chain: 'A', color: '#599a97' },
+    { start: '11', end: '20', chain: 'A', color: '#28b525' },
+    { start: '21', end: '30', chain: 'A', color: '#008a7c' },
+    { start: '31', end: '40', chain: 'A', color: '#0faa05' },
+    { start: '41', end: '50', chain: 'A', color: '#f8cb31' },
+    { start: '51', end: '60', chain: 'A', color: '#77cb1c' },
+    { start: '61', end: '70', chain: 'A', color: '#36ec09' },
+    { start: '71', end: '80', chain: 'A', color: '#cbf17b' },
+    { start: '81', end: '90', chain: 'A', color: '#5cb185' },
+    { start: '91', end: '100', chain: 'A', color: '#fee954' },
   ];
 
   // Define different loci to display
@@ -87,14 +88,14 @@ export class SectionSourcesComponent {
 
   // Define light settings
   readonly LIGHT: Partial<Settings> = {
-    'background-color' : '#dee2e6',
-    'backbone-color' : '#ffffff',
+    'background-color': '#dee2e6',
+    'backbone-color': '#ffffff',
   };
 
   // Define dark settings
   readonly DARK: Partial<Settings> = {
-    'background-color' : '#1a1d20',
-    'backbone-color' : '#ffffff',
+    'background-color': '#1a1d20',
+    'backbone-color': '#ffffff',
   };
 
   // Define fixed settings

--- a/projects/ngx-structure-viewer/src/lib/interfaces/source.ts
+++ b/projects/ngx-structure-viewer/src/lib/interfaces/source.ts
@@ -20,4 +20,6 @@ export type Source = (Local | Remote) & {
     label: string;
     // Whether data is binary or not
     binary: boolean;
+    // Define chain
+    chain?: string;
 }

--- a/projects/ngx-structure-viewer/src/lib/services/structure.service.ts
+++ b/projects/ngx-structure-viewer/src/lib/services/structure.service.ts
@@ -2,6 +2,8 @@ import { EventEmitter, Injectable } from '@angular/core';
 import { Structure, StructureProperties } from 'molstar/lib/mol-model/structure';
 import { StateObject, StateObjectSelector } from 'molstar/lib/mol-state';
 import { StateTransformer } from 'molstar/lib/mol-state/transformer';
+import { StateTransforms } from 'molstar/lib/mol-plugin-state/transforms';
+import { MolScriptBuilder as MS } from 'molstar/lib/mol-script/language/builder';
 import { Asset } from 'molstar/lib/mol-util/assets';
 import {
   BehaviorSubject,
@@ -180,7 +182,23 @@ export class StructureService {
     // Create model
     const model = await plugin.builders.structure.createModel(parsed, {modelIndex : 0});
     // Create structure
-    return plugin.builders.structure.createStructure(model, {name : 'model', params : {}});
+    let structure = await plugin.builders.structure.createStructure(model, {name : 'model', params : {}});
+
+    // Case chain is defined
+    if (source.chain) {
+      // Get chain property based on settings
+      const chainProperty = this.settingsService.settings.prefer_label_asym_id 
+        ? MS.struct.atomProperty.macromolecular.label_asym_id()
+        : MS.struct.atomProperty.macromolecular.auth_asym_id();
+      // Define expression
+      const expression = MS.struct.generator.atomGroups({
+        'chain-test': MS.core.rel.eq([chainProperty, source.chain])
+      });
+      // Apply selection
+      structure = await plugin.state.data.build().to(structure).apply(StateTransforms.Model.StructureSelectionFromExpression, { expression, label: `Chain ${source.chain}` }).commit();
+    }
+
+    return structure;
   }
 
   protected setResidues(structure: Structure, prefer_label_asym_id = false): void {


### PR DESCRIPTION
Added a chain property to the Source interface. The viewer now uses Molstar's StructureSelectionFromExpression to automatically filter the loaded structure to the specified chain. Supports toggling between auth_asym_id and label_asym_id depending on user settings.
inspo : https://molstar.org/docs/plugin/selections/#selection-queries